### PR TITLE
feat: Add configurators for Dropdown and Combobox

### DIFF
--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/ComboBoxConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/ComboBoxConfigurator.kt
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2023-2024 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.catalog.configurator.samples.textfields
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.catalog.model.Configurator
+import com.adevinta.spark.catalog.themes.SegmentedButton
+import com.adevinta.spark.catalog.util.SampleSourceUrl
+import com.adevinta.spark.components.menu.DropdownMenuItem
+import com.adevinta.spark.components.text.Text
+import com.adevinta.spark.components.textfields.AddonScope
+import com.adevinta.spark.components.textfields.SelectTextField
+import com.adevinta.spark.components.textfields.TextField
+import com.adevinta.spark.components.textfields.TextFieldState
+import com.adevinta.spark.components.toggles.SwitchLabelled
+
+public val ComboBoxConfigurator: Configurator = Configurator(
+    name = "ComboBox",
+    description = "ComboBox configuration",
+    sourceUrl = "$SampleSourceUrl/ComboBoxSamples.kt",
+) {
+    ComboBoxSample()
+}
+
+@Composable
+private fun ColumnScope.ComboBoxSample() {
+    var isEnabled by remember { mutableStateOf(true) }
+    var expanded by remember { mutableStateOf(false) }
+    var isRequired by remember { mutableStateOf(true) }
+    var state: TextFieldState? by remember { mutableStateOf(null) }
+    var labelText by remember { mutableStateOf("Label") }
+    var valueText by remember { mutableStateOf("Value") }
+    var placeHolderText by remember { mutableStateOf("Placeholder") }
+    var helperText by remember { mutableStateOf("Helper message") }
+    var stateMessageText by remember { mutableStateOf("State Message") }
+    var addonText: String? by remember { mutableStateOf(null) }
+
+    val leadingContent: (@Composable AddonScope.() -> Unit)? = addonText?.let {
+        @Composable {
+            Text(it)
+        }
+    }
+
+    SwitchLabelled(
+        checked = expanded,
+        onCheckedChange = { expanded = it },
+    ) {
+        Text(
+            text = "Expanded",
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+
+    SelectTextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = valueText,
+        onValueChange = {},
+        expanded = expanded,
+        onExpandedChange = { expanded = !expanded },
+        onDismissRequest = { expanded = false },
+        enabled = isEnabled,
+        readOnly = false,
+        required = isRequired,
+        label = labelText,
+        placeholder = placeHolderText,
+        helper = helperText,
+        leadingContent = leadingContent,
+        state = state,
+        stateMessage = stateMessageText,
+    ) {
+        repeat(5) {
+            DropdownMenuItem(
+                text = { Text("Item $it") },
+                onClick = { expanded = false },
+            )
+        }
+    }
+
+    SwitchLabelled(
+        checked = isRequired,
+        onCheckedChange = { isRequired = it },
+    ) {
+        Text(
+            text = "Required",
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+    SwitchLabelled(
+        checked = isEnabled,
+        onCheckedChange = { isEnabled = it },
+    ) {
+        Text(
+            text = "Enabled",
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+
+    Column {
+        Text(
+            text = "State",
+            modifier = Modifier.padding(bottom = 8.dp),
+            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
+        )
+        val textFieldStates: MutableSet<TextFieldState?> =
+            TextFieldState.entries.toMutableSet<TextFieldState?>().apply { add(null) }
+        val buttonStylesLabel = textFieldStates.map { it?.run { name } ?: "Default" }
+        SegmentedButton(
+            options = buttonStylesLabel,
+            selectedOption = state?.name ?: "Default",
+            onOptionSelect = { state = if (it == "Default") null else TextFieldState.valueOf(it) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(48.dp),
+        )
+    }
+
+    TextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = labelText,
+        onValueChange = {
+            labelText = it
+        },
+        label = "Label text",
+        placeholder = "Label of the ComboBox",
+    )
+    TextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = placeHolderText,
+        onValueChange = {
+            placeHolderText = it
+        },
+        label = "Placeholder text",
+        placeholder = "Placeholder of the ComboBox",
+    )
+    TextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = helperText,
+        onValueChange = {
+            helperText = it
+        },
+        label = "Helper text",
+        placeholder = "Helper of the ComboBox",
+    )
+    TextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = stateMessageText,
+        onValueChange = {
+            stateMessageText = it
+        },
+        label = "State message",
+        placeholder = "State message of the ComboBox",
+    )
+    TextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = addonText ?: "",
+        onValueChange = {
+            addonText = it.ifBlank { null }
+        },
+        label = "Prefix",
+        placeholder = "State message of the ComboBox",
+    )
+}

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/DropdownsConfigurator.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/configurator/samples/textfields/DropdownsConfigurator.kt
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2023-2024 Adevinta
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.adevinta.spark.catalog.configurator.samples.textfields
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.adevinta.spark.SparkTheme
+import com.adevinta.spark.catalog.model.Configurator
+import com.adevinta.spark.catalog.themes.SegmentedButton
+import com.adevinta.spark.catalog.util.SampleSourceUrl
+import com.adevinta.spark.components.menu.DropdownMenuItem
+import com.adevinta.spark.components.text.Text
+import com.adevinta.spark.components.textfields.AddonScope
+import com.adevinta.spark.components.textfields.SelectTextField
+import com.adevinta.spark.components.textfields.TextField
+import com.adevinta.spark.components.textfields.TextFieldState
+import com.adevinta.spark.components.toggles.SwitchLabelled
+
+public val DropdownsConfigurator: Configurator = Configurator(
+    name = "Dropdowns",
+    description = "Dropdowns configuration",
+    sourceUrl = "$SampleSourceUrl/DropdownSamples.kt",
+) {
+    DropdownSample()
+}
+
+@Composable
+private fun ColumnScope.DropdownSample() {
+    var isEnabled by remember { mutableStateOf(true) }
+    var expanded by remember { mutableStateOf(false) }
+    var isRequired by remember { mutableStateOf(true) }
+    var state: TextFieldState? by remember { mutableStateOf(null) }
+    var labelText by remember { mutableStateOf("Label") }
+    var valueText by remember { mutableStateOf("Value") }
+    var placeHolderText by remember { mutableStateOf("Placeholder") }
+    var helperText by remember { mutableStateOf("Helper message") }
+    var stateMessageText by remember { mutableStateOf("State Message") }
+    var addonText: String? by remember { mutableStateOf(null) }
+
+    val leadingContent: (@Composable AddonScope.() -> Unit)? = addonText?.let {
+        @Composable {
+            Text(it)
+        }
+    }
+
+    SwitchLabelled(
+        checked = expanded,
+        onCheckedChange = { expanded = it },
+    ) {
+        Text(
+            text = "Expanded",
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+
+    SelectTextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = valueText,
+        onValueChange = {},
+        expanded = expanded,
+        onExpandedChange = { expanded = !expanded },
+        onDismissRequest = { expanded = false },
+        enabled = isEnabled,
+        readOnly = true,
+        required = isRequired,
+        label = labelText,
+        placeholder = placeHolderText,
+        helper = helperText,
+        leadingContent = leadingContent,
+        state = state,
+        stateMessage = stateMessageText,
+    ) {
+        repeat(5) {
+            DropdownMenuItem(
+                text = { Text("Item $it") },
+                onClick = { expanded = false },
+            )
+        }
+    }
+
+    SwitchLabelled(
+        checked = isRequired,
+        onCheckedChange = { isRequired = it },
+    ) {
+        Text(
+            text = "Required",
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+    SwitchLabelled(
+        checked = isEnabled,
+        onCheckedChange = { isEnabled = it },
+    ) {
+        Text(
+            text = "Enabled",
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+
+    Column {
+        Text(
+            text = "State",
+            modifier = Modifier.padding(bottom = 8.dp),
+            style = SparkTheme.typography.body2.copy(fontWeight = FontWeight.Bold),
+        )
+        val textFieldStates: MutableSet<TextFieldState?> =
+            TextFieldState.entries.toMutableSet<TextFieldState?>().apply { add(null) }
+        val buttonStylesLabel = textFieldStates.map { it?.run { name } ?: "Default" }
+        SegmentedButton(
+            options = buttonStylesLabel,
+            selectedOption = state?.name ?: "Default",
+            onOptionSelect = { state = if (it == "Default") null else TextFieldState.valueOf(it) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(48.dp),
+        )
+    }
+
+    TextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = labelText,
+        onValueChange = {
+            labelText = it
+        },
+        label = "Label text",
+        placeholder = "Label of the Dropdown",
+    )
+    TextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = placeHolderText,
+        onValueChange = {
+            placeHolderText = it
+        },
+        label = "Placeholder text",
+        placeholder = "Placeholder of the Dropdown",
+    )
+    TextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = helperText,
+        onValueChange = {
+            helperText = it
+        },
+        label = "Helper text",
+        placeholder = "Helper of the Dropdown",
+    )
+    TextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = stateMessageText,
+        onValueChange = {
+            stateMessageText = it
+        },
+        label = "State message",
+        placeholder = "State message of the Dropdown",
+    )
+    TextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = addonText ?: "",
+        onValueChange = {
+            addonText = it.ifBlank { null }
+        },
+        label = "Prefix",
+        placeholder = "State message of the Dropdown",
+    )
+}

--- a/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Components.kt
+++ b/catalog/src/main/kotlin/com/adevinta/spark/catalog/model/Components.kt
@@ -37,6 +37,7 @@ import com.adevinta.spark.catalog.configurator.samples.slider.SlidersConfigurato
 import com.adevinta.spark.catalog.configurator.samples.tabs.TabsConfigurator
 import com.adevinta.spark.catalog.configurator.samples.tags.TagsConfigurator
 import com.adevinta.spark.catalog.configurator.samples.text.TextLinksConfigurator
+import com.adevinta.spark.catalog.configurator.samples.textfields.DropdownsConfigurator
 import com.adevinta.spark.catalog.configurator.samples.textfields.TextFieldsConfigurator
 import com.adevinta.spark.catalog.configurator.samples.toggles.CheckboxConfigurator
 import com.adevinta.spark.catalog.configurator.samples.toggles.RadioButtonConfigurator
@@ -126,6 +127,17 @@ private val Dialogs = Component(
     sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/spark/components/dialog/ModalScaffold.kt",
     examples = DialogsExamples,
     configurator = null,
+)
+
+private val Dropdowns = Component(
+    id = nextId(),
+    name = "Dropdowns",
+    description = R.string.component_dialog_description,
+    guidelinesUrl = "$ComponentGuidelinesUrl/p/1186e1705/p/323b83-dropdown",
+    docsUrl = "$PackageSummaryUrl/com.adevinta.spark.components.dropdown/index.html",
+    sourceUrl = "$SparkSourceUrl/kotlin/com/adevinta/spark/components/textfields/Dropdown.kt",
+    examples = listOf(),
+    configurator = DropdownsConfigurator,
 )
 
 private val IconButtons = Component(
@@ -326,6 +338,7 @@ public val Components: List<Component> = listOf(
     Checkboxes,
     Chips,
     Dialogs,
+    Dropdowns,
     IconButtons,
     IconToggleButtons,
     Popovers,

--- a/catalog/src/main/res/values/strings.xml
+++ b/catalog/src/main/res/values/strings.xml
@@ -61,6 +61,11 @@
     <!--endregion-->
 
     <string name="component_dialog_description">A dialog is a modal window that appears in front of content to provide critical information or ask for a decision.</string>
+    <!--Dropdowns example-->
+    <string name="component_dropdowns_description_simple">A dropdown displays a list of items to a user.</string>
+    <string name="component_dropdowns_description">Dropdown is an interactive element that allows users to select an option from a list of choices presented in a collapsible menu. It saves space on the interface by concealing the options until the user interacts with the component.</string>
+    <!--endregion-->
+
     <string name="component_tab_description">Tabs are used to group different but related content, allowing users to navigate views without leaving the page. They always contain at least two items and one tab is active at a time.</string>
     <string name="component_textfield_description">The input / text-field component allows users to write in the space provided for the content.</string>
     <string name="component_tokens_description">The tokens are the basis of this Design System and allow each brand to choose its colors, shapes, typos and icons.</string>

--- a/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/BottomSheet.kt
+++ b/spark/src/main/kotlin/com/adevinta/spark/components/bottomsheet/BottomSheet.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.adevinta.spark.SparkTheme
 import com.adevinta.spark.components.bottomsheet.SheetDefaults.ContentTopPadding
 import com.adevinta.spark.components.bottomsheet.SheetDefaults.ContentTopPaddingNoHandle
 import com.adevinta.spark.components.buttons.ButtonFilled
@@ -145,7 +146,7 @@ internal fun SparkModalBottomSheet(
     modifier: Modifier = Modifier,
     sheetState: SheetState = rememberModalBottomSheetState(),
     shape: Shape = ExpandedShape,
-    containerColor: Color = SheetDefaults.ContainerColor,
+    containerColor: Color = SparkTheme.colors.surface,
     contentColor: Color = contentColorFor(containerColor),
     dragHandle: @Composable (() -> Unit)? = {
         DragHandle()


### PR DESCRIPTION
<!--
  Please remove sections wisely!
  And checkout the contribution docs at https://github.com/adevinta/spark-android/blob/main/docs/contributing.md
-->

## 📋 Changes

<!-- Describe your changes in details -->

## 🤔 Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it solves an issue, add the steps to reproduce it. -->
<!-- Closes #1234 -->

## ✅ Checklist

<!-- Feel free to add or remove entries -->
- [ ] I have reviewed the submitted code.
- [ ] I have tested on a phone device/emulator.
- [ ] If it includes design changes, please ask for a review `spark-design` GitHub team.

## 📸 Screenshots

<!-- Insert your screenshots here -->

## 🗒️ Other info

<!-- Feel free to add any other info here if needed -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a configurator for ComboBox components, allowing customization of behavior and appearance.
  - Added configurators for dropdown components, enabling extensive customization options.
  - Integrated a new `Dropdowns` component with detailed configuration options.

- **Documentation**
  - Enhanced documentation with descriptions for dropdown components, detailing their functionality and usage.

- **Style**
  - Updated `BottomSheet` component to use theme-based colors for better consistency with the overall design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->